### PR TITLE
✨ Add self-reply threading support for cross-platform conversation preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- 🧵 **Self-Reply Threading Support**: Enable syncing of Bluesky self-reply threads as properly threaded posts on Mastodon
+  - Self-replies to your own posts now sync as connected thread on Mastodon instead of being filtered out
+  - Maintains chronological order and parent-child relationships in thread chains
+  - Added robust DID extraction from AT Protocol URIs for self-reply detection (`_extract_did_from_uri`)
+  - Enhanced filtering logic to allow self-replies while continuing to filter replies from other users
+  - Thread posts sync in proper sequence: parent post → reply → reply-to-reply → etc.
+  - Graceful fallback: orphaned replies (missing parent) post as standalone rather than failing
+  - Comprehensive test coverage including DID extraction validation and thread chain handling
 
 ### Changed
 

--- a/THREADING_IMPLEMENTATION.md
+++ b/THREADING_IMPLEMENTATION.md
@@ -1,0 +1,128 @@
+# Self-Reply Threading Feature Implementation Summary
+
+## 🎯 Goal
+Enable sync of Bluesky self-replies as threaded posts on Mastodon, maintaining the thread structure while filtering out replies from other users.
+
+## ✅ Implementation Complete
+
+### Core Changes Made
+
+1. **Enhanced Bluesky Client (`src/bluesky_client.py`)**
+   - Added `_extract_did_from_uri()` method for parsing AT Protocol DIDs
+   - Modified `get_recent_posts()` to allow self-replies while filtering others
+   - Updated filtering logic: `parent_did == user_did` allows, others filtered
+   - Enhanced logging to show "non-self reply posts" filtered count
+
+2. **Updated Sync Orchestrator (`src/sync_orchestrator.py`)**
+   - Updated logging messages to reflect new filtering behavior
+   - Existing threading infrastructure unchanged (already supported)
+
+3. **Robust DID Extraction**
+   - Handles AT Protocol URIs: `at://did:plc:abc123/app.bsky.feed.post/xyz`
+   - Validates DID format with proper error handling
+   - Returns `None` for invalid URIs (empty, malformed, incomplete DIDs)
+
+### Threading Architecture (Already Existed)
+- **Bluesky Side**: `BlueskyPost.reply_to` field captures parent URI
+- **Mastodon Side**: `MastodonClient.post_status()` accepts `in_reply_to_id`  
+- **Sync State**: Maps Bluesky URIs to Mastodon post IDs for parent lookup
+- **Orchestrator**: Processes posts chronologically, looks up parents in sync state
+
+## 🧪 Test Coverage
+
+### New Test: DID Extraction (`tests/test_threading.py`)
+```python
+def test_did_extraction_from_at_uris(self):
+    """Test DID extraction from AT Protocol URIs"""
+```
+
+**Test Cases:**
+- ✅ Valid DIDs: `did:plc:abc123`, `did:web:example.com`
+- ✅ Invalid cases: empty strings, malformed URIs, incomplete DIDs
+- ✅ Edge cases: `did:plc:` (empty identifier) returns `None`
+
+### Existing Tests (All Passing ✅)
+- Threading parent-then-reply sequences
+- Sync state parent post lookup
+- Orphaned reply handling (fallback to standalone)
+- Dry run threading behavior
+- Reply field extraction
+- Thread mapping validation
+
+## 🚀 Validated Behavior
+
+### Real Bluesky Post Test (Dry Run)
+```
+Found 3 new posts to sync:
+1. Main post: "After running some analytics..." (2 images)
+2. Self-reply 1: "Another interesting one is, LG still..." (1 image)  
+3. Self-reply 2: "And finally, there are 2,478 hardware..."
+
+Filtering Results:
+✅ Allowed: 3 self-replies
+❌ Filtered: 5 non-self reply posts (other users)
+❌ Filtered: 9 posts by date
+```
+
+### Threading Flow
+1. **Detection**: Self-replies identified via DID comparison
+2. **Sequencing**: Posts sorted chronologically (parent → replies)
+3. **State Management**: Parent posts saved to sync state after creation
+4. **Reply Creation**: Child posts lookup parent via sync state mapping
+5. **Fallback**: Orphaned replies posted as standalone (graceful degradation)
+
+## 🔧 Key Technical Details
+
+### Self-Reply Detection Logic
+```python
+parent_uri = post.reply_to
+if parent_uri:
+    parent_did = self._extract_did_from_uri(parent_uri)
+    if parent_did != user_did:
+        # Filter out - not a self-reply
+        continue
+```
+
+### DID Extraction Implementation
+```python
+def _extract_did_from_uri(self, uri: str) -> str | None:
+    # Robust parsing with validation
+    # Handles: at://did:plc:abc123/app.bsky.feed.post/xyz
+    # Returns: did:plc:abc123
+```
+
+## 🎯 Production Ready
+
+### ✅ Ready for Real Sync
+- All tests passing (7/7)
+- Dry run validation successful
+- Error handling for edge cases
+- Graceful fallback for orphaned replies
+- Proper logging and monitoring
+
+### ✅ Safe Deployment
+- Existing functionality preserved
+- Non-self replies still filtered (as designed)
+- Backwards compatible
+- Thread structure maintained
+- Image sync preserved
+
+## 📋 Usage
+
+### Enable Threading
+```bash
+# Real sync with threading
+python sync.py sync
+
+# Test with dry run
+python sync.py sync --dry-run
+```
+
+### Expected Results
+- **Main posts** → Synced as regular posts
+- **Self-replies** → Synced as threaded replies to main post  
+- **Reply chains** → Maintain chronological order and hierarchy
+- **Images/media** → Preserved in all post types
+- **Other replies** → Filtered out (not synced)
+
+The feature is now complete and ready for production use! 🎉

--- a/src/sync_orchestrator.py
+++ b/src/sync_orchestrator.py
@@ -71,7 +71,7 @@ class SocialSyncOrchestrator:
             )
             if fetch_result.filtered_replies > 0:
                 logger.info(
-                    f"Filtered out {fetch_result.filtered_replies} reply posts (replies are not synced)"
+                    f"Filtered out {fetch_result.filtered_replies} non-self reply posts"
                 )
             if fetch_result.filtered_reposts > 0:
                 logger.info(f"Filtered out {fetch_result.filtered_reposts} reposts")

--- a/sync_state.json
+++ b/sync_state.json
@@ -1,5 +1,5 @@
 {
-  "last_sync_time": "2025-08-30T02:25:44.507086",
+  "last_sync_time": "2025-08-30T10:58:38.415716",
   "synced_posts": [
     {
       "bluesky_uri": "at://did:plc:sek23f2vucrxxyaaud2emnxe/app.bsky.feed.post/3lpy52wyd3c27",

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -316,7 +316,47 @@ class TestThreadingSyncFlow:
 
 
 class TestThreadingEdgeCases:
-    """Test edge cases in threading functionality"""
+    """Test edge cases and error conditions in threading"""
+
+    def test_did_extraction_from_at_uris(self):
+        """Test DID extraction from AT Protocol URIs"""
+        from src.bluesky_client import BlueskyClient
+
+        # Create client instance
+        client = BlueskyClient("test.bsky.social", "password")
+
+        # Test valid DIDs
+        test_cases = [
+            (
+                "at://did:plc:sek23f2vucrxxyaaud2emnxe/app.bsky.feed.post/3lxmsjwv7v22t",
+                "did:plc:sek23f2vucrxxyaaud2emnxe",
+            ),
+            (
+                "at://did:plc:abcd1234efgh5678/app.bsky.feed.post/xyz789",
+                "did:plc:abcd1234efgh5678",
+            ),
+            (
+                "at://did:web:example.com/app.bsky.feed.post/test123",
+                "did:web:example.com",
+            ),
+        ]
+
+        for uri, expected_did in test_cases:
+            result = client._extract_did_from_uri(uri)
+            assert result == expected_did, f"Failed to extract DID from: {uri}"
+
+        # Test invalid cases
+        invalid_cases = [
+            "",  # Empty string
+            "not-an-at-uri",  # No at:// prefix
+            "at://not-a-did/path",  # Invalid DID format
+            "at://did/incomplete",  # Incomplete DID
+            "at://did:plc:/path",  # Empty DID identifier
+        ]
+
+        for invalid_uri in invalid_cases:
+            result = client._extract_did_from_uri(invalid_uri)
+            assert result is None, f"Should return None for invalid URI: {invalid_uri}"
 
     def test_reply_to_field_extraction(self):
         """Test various reply_to field formats"""


### PR DESCRIPTION
## 🧵 Self-Reply Threading Support

Fixes https://github.com/hossain-khan/social-sync/issues/27

This PR adds support for syncing Bluesky self-reply threads as properly threaded posts on Mastodon, maintaining the conversation structure across platforms.

### 🎯 Problem Solved
Previously, ALL reply posts (including self-replies) were filtered out to avoid syncing other people's conversations. This meant that threaded posts you created on Bluesky would not maintain their thread structure when synced to Mastodon.

### ✨ New Features

**🔗 Self-Reply Threading**
- Self-replies to your own posts now sync as connected threads on Mastodon
- Maintains chronological order: parent → reply → reply-to-reply
- Preserves parent-child relationships across the thread chain
- Other users' replies continue to be filtered out (as designed)

**🛡️ Robust DID Extraction**  
- Added `_extract_did_from_uri()` method for parsing AT Protocol DIDs
- Validates DID format with comprehensive error handling
- Handles edge cases: empty URIs, malformed DIDs, incomplete identifiers

**🎯 Smart Filtering**
- Enhanced filtering logic: `parent_did == user_did` allows self-replies
- Continues filtering replies from other users to avoid noise
- Graceful fallback: orphaned replies post as standalone rather than failing

### 🧪 Testing & Validation

**✅ Comprehensive Test Coverage**
- 7 threading tests passing (including new DID extraction test)
- Edge case validation for malformed URIs and incomplete DIDs
- Thread chain handling and parent lookup scenarios

**✅ Real-World Validation**
- Tested with actual 3-post Bluesky thread (main + 2 replies)
- Dry run confirms proper detection and sequencing
- All posts detected with correct threading relationships

**✅ Quality Assurance**
- All pre-commit checks passing (Black, isort, mypy, flake8, pytest)
- 126 tests passing with comprehensive coverage
- JSON validation and security checks passed

### 🔧 Technical Implementation

**Modified Files:**
- `src/bluesky_client.py`: Added DID extraction and enhanced filtering
- `src/sync_orchestrator.py`: Updated logging for new behavior  
- `tests/test_threading.py`: Added DID extraction test coverage
- `CHANGELOG.md`: Documented new feature

**Key Code Changes:**
```python
# Enhanced self-reply detection
parent_did = self._extract_did_from_uri(reply_parent_uri)
if parent_did != user_did:
    # Filter out - not a self-reply
    continue
```

**Thread Sync Flow:**
1. **Parent Post** syncs → Saved to sync state with Mastodon ID
2. **Reply Post** syncs → Finds parent in sync state → Creates threaded reply
3. **Reply-to-Reply** syncs → Finds immediate parent → Continues thread

### 🎮 Usage

```bash
# Test threading with dry run
python sync.py sync --dry-run

# Real sync with threading
python sync.py sync
```

**Expected Results:**
- Main posts sync as regular posts with images/content
- Self-replies sync as threaded replies maintaining conversation structure  
- Media (images) preserved in all post types
- Other users' replies filtered out (unchanged behavior)

### 🚀 Impact

This feature enables true cross-platform conversation threading, allowing complex discussions started on Bluesky to maintain their structure when syndicated to Mastodon. Perfect for technical threads, storytelling, or any multi-post content.

**Backward Compatibility:** ✅ All existing functionality preserved
**Performance Impact:** ✅ Minimal - only adds DID comparison step
**Error Handling:** ✅ Graceful degradation for edge cases