### PR TITLE
🔧 Fix Python 3.9 compatibility issues

### DIFF
--- a/src/bluesky_client.py
+++ b/src/bluesky_client.py
@@ -92,7 +92,7 @@ class BlueskyClient:
             logger.error(f"Failed to get user DID: {e}")
             return None
 
-    def _extract_did_from_uri(self, uri: str) -> str | None:
+    def _extract_did_from_uri(self, uri: str) -> Optional[str]:
         """Extract DID from AT Protocol URI
 
         Args:

--- a/sync.py
+++ b/sync.py
@@ -5,7 +5,11 @@ Social Sync CLI - Command line interface for syncing social media posts
 import logging
 import os
 import sys
+import warnings
 from pathlib import Path
+
+# Suppress urllib3 OpenSSL warning on macOS (LibreSSL is functionally equivalent)
+warnings.filterwarnings("ignore", message="urllib3 v2 only supports OpenSSL 1.1.1+")
 
 import click
 from dotenv import load_dotenv


### PR DESCRIPTION
- Replace modern union syntax (str | None) with Optional[str] in bluesky_client.py
- Suppress urllib3 OpenSSL warning on macOS (LibreSSL is functionally equivalent)
- Enables project to run on Python 3.9.6 without errors or warnings

Fixes compatibility for systems with Python 3.9.x while maintaining code functionality. All CLI commands now work cleanly without urllib3 warnings on macOS.