### PR TITLE
🚀 Release 0.6.0: Fix recordWithMedia image sync bug

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2025-10-27
+
+### Fixed
+- 🐛 **recordWithMedia Image Sync Bug**: Fixed critical issue where Bluesky posts with quoted content and images failed to sync images to Mastodon
+  - Posts using `app.bsky.embed.recordWithMedia` embed type (quoted posts with images) would sync to Mastodon without any attached images
+  - Root cause: Images in recordWithMedia embeds are nested at `embed.media.images` instead of `embed.images`
+  - **BlueskyClient Fix**: Enhanced `_extract_embed_data()` method to check both direct images (`embed.images`) and nested media images (`embed.media.images`)
+  - **ContentProcessor Fix**: Updated `extract_images_from_embed()` to process both "images" and "recordWithMedia" embed types
+  - Added comprehensive unit test coverage for recordWithMedia scenarios in both BlueskyClient and ContentProcessor
+  - Fixed pre-existing test failures caused by new media attribute checks
+  - Verified with real-world post containing 4 images - all images now sync correctly
+  - Affects any Bluesky post that quotes another post while also attaching images
+
 ## [0.5.0] - 2025-10-20
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "social-sync"
-version = "0.5.0"
+version = "0.6.0"
 description = "Cross-platform social media synchronization tool for Bluesky and Mastodon"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/social_sync/__init__.py
+++ b/src/social_sync/__init__.py
@@ -6,7 +6,7 @@ maintaining conversation threading and providing comprehensive
 operational visibility.
 """
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 __author__ = "Hossain Khan"
 __email__ = "hello@hossain.dev"
 __license__ = "MIT"


### PR DESCRIPTION
## Release 0.6.0

This release fixes a critical bug where Bluesky posts with quoted content and images failed to sync images to Mastodon.

### Fixed
- 🐛 **recordWithMedia Image Sync Bug**: Fixed critical issue where Bluesky posts with quoted content and images failed to sync images to Mastodon
  - Posts using `app.bsky.embed.recordWithMedia` embed type (quoted posts with images) would sync to Mastodon without any attached images
  - Root cause: Images in recordWithMedia embeds are nested at `embed.media.images` instead of `embed.images`
  - **BlueskyClient Fix**: Enhanced `_extract_embed_data()` method to check both direct images (`embed.images`) and nested media images (`embed.media.images`)
  - **ContentProcessor Fix**: Updated `extract_images_from_embed()` to process both "images" and "recordWithMedia" embed types
  - Added comprehensive unit test coverage for recordWithMedia scenarios in both BlueskyClient and ContentProcessor
  - Fixed pre-existing test failures caused by new media attribute checks
  - Verified with real-world post containing 4 images - all images now sync correctly
  - Affects any Bluesky post that quotes another post while also attaching images

### Changes in This PR
- Updated `pyproject.toml` version: `0.5.0` → `0.6.0`
- Updated `src/social_sync/__init__.py` version: `0.5.0` → `0.6.0`
- Updated `docs/CHANGELOG.md` with 0.6.0 release notes

### Testing
- ✅ All 281 tests passing
- ✅ Pre-commit quality checks passed
- ✅ Real-world verification with 4-image post successful

### Related
- Original fix merged in PR #61

---

**Release Type:** Bug Fix (Patch)
**Semver:** 0.6.0