### PR TITLE
📝 Update CHANGELOG for PR #77 - Language tag support for i18n metadata

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixes issue where posts with "🎉 Check out example.co..." would fail to expand URLs correctly
 
 ### Added
+- ✨ **Language Tag Support**: Added i18n metadata preservation when syncing posts from Bluesky to Mastodon
+  - Bluesky posts with ISO 639-1 language codes (`langs` field) now preserve language metadata on Mastodon
+  - Added `langs: Optional[List[str]]` field to `BlueskyPost` dataclass for language tag extraction
+  - Added `language: Optional[str]` parameter to `MastodonClient.post_status()` for language tag support
+  - When multiple languages present, uses first language tag (Mastodon accepts single tag)
+  - Added `ContentProcessor.validate_language_code()` with 38 common ISO 639-1 codes for validation
+  - Enables language-based filtering, translation features, and improved discoverability on Mastodon
+  - Comprehensive test coverage with 18 new tests for extraction, validation, and integration scenarios
+  - All 318 tests passing after implementation
 - ✨ **Content Warning Support**: Added automatic content warning sync from Bluesky self-labels to Mastodon
   - Bluesky posts with self-labels (`porn`, `nudity`, `sexual`, `graphic-media`) now sync with appropriate Mastodon content warnings
   - Self-labels are extracted from Bluesky posts and mapped to user-friendly content warning text


### PR DESCRIPTION
## Summary

Updates `docs/CHANGELOG.md` to document the language tag support feature added in PR #77.

## Changes

Added comprehensive documentation under the **[Unreleased]** section's **Added** category for:

- ✨ **Language Tag Support**: i18n metadata preservation from Bluesky to Mastodon
  - ISO 639-1 language code extraction and transfer
  - New `langs` field in `BlueskyPost` dataclass
  - New `language` parameter in `MastodonClient.post_status()`
  - Language code validation with 38 common codes
  - Multi-language handling (uses first tag for Mastodon)
  - 18 new tests, 318 total tests passing

## Related

- Closes #77 (merged PR documentation)
- References #70 (original issue for language tag support)

## Documentation

This is a documentation-only change with no code modifications.