### PR TITLE
📝 Update documentation to reflect quote post filtering behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ A Python-based tool to automatically sync posts from Bluesky to Mastodon with Gi
 - 🚀 **GitHub Actions**: Run automatically via CI/CD workflows
 - 🎯 **Smart Deduplication**: Prevents duplicate posts across sync runs
 - 🚫 **Selective Sync**: Skip posts with `#no-sync` tag to control what gets synced
-- 📝 **Content Processing**: Handles links, images, and quoted posts
+- 🔍 **Smart Filtering**: Filters out replies to others, reposts, and quotes of other people's content
+- 📝 **Content Processing**: Handles links, images, and self-quoted posts
 - 🧪 **Dry Run Mode**: Test functionality without actual posting
 
 ## 🚀 Quick Start

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -254,13 +254,14 @@ python sync.py sync --since-date 2025-01-01
 - ✅ **Text posts** - Plain text content
 - ✅ **Posts with links** - External URLs with preview
 - ✅ **Posts with images** - Images with alt text
-- ✅ **Quoted posts** - Includes quoted content
+- ✅ **Self-quoted posts** - Your quotes of your own content
 - ✅ **Threaded posts** - Reply posts with conversation context
 
 ### What Doesn't Get Synced
 
 - ❌ **Other user replies** - Unless parent was also synced
 - ❌ **Reposts/boosts** - Only original content
+- ❌ **Quotes of others** - Quote posts of other people's content
 - ❌ **Already synced** - Prevented by state tracking
 - ❌ **Posts with `#no-sync` tag** - Skipped and tracked to prevent re-processing
 
@@ -270,7 +271,7 @@ python sync.py sync --since-date 2025-01-01
 - **Character limits**: Long posts truncated to 500 characters
 - **Link embedding**: Bluesky link cards converted to text with URLs  
 - **Image handling**: Notes image count and preserves alt text
-- **Quote posts**: Includes quoted content with attribution
+- **Self-quote posts**: Includes your quoted content with attribution (quotes of others filtered)
 - **Attribution**: Adds "(via Bluesky)" to posts (skipped for replies)
 
 ### Language Tag Support


### PR DESCRIPTION
## 📝 Documentation Updates

Updates project documentation to accurately reflect the quote post filtering behavior introduced in PR #90.

## Changes

### README.md
- ✨ Added **Smart Filtering** feature to highlight reply/repost/quote filtering
- 📝 Changed "quoted posts" → "self-quoted posts" to clarify filtering behavior

### docs/SETUP.md
**What Gets Synced:**
- ✅ Changed "Quoted posts" → "Self-quoted posts" (your quotes of your own content)

**What Doesn't Get Synced:**
- ❌ Added "Quotes of others" (quote posts of other people's content)

**Content Adaptations:**
- 📝 Updated "Quote posts" → "Self-quote posts" with clarification that quotes of others are filtered

## Why These Changes

The recent quote post filtering fix (PR #90) filters out quote posts of other people's content while allowing self-quotes. The previous documentation didn't distinguish between these cases, which could confuse users about what content gets synced.

## Documentation Accuracy

Now the docs accurately state:
- Self-quotes (quoting your own posts) → ✅ Synced
- Quotes of others' posts → ❌ Filtered out (along with replies to others and reposts)

This aligns with the actual implementation and helps users understand sync behavior.

## Related

- Closes: N/A (documentation only)
- Related to: PR #90 (quote post filtering implementation)