### PR TITLE
🏗️ Prepare release 0.9.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+### Security
+
+## [0.9.0] - 2026-04-12
+
+### Added
 - 📦 **Standalone Binary Distribution**: Package Social Sync CLI as standalone executables using PyInstaller
   - Pre-built binaries for macOS (arm64, x86_64) and Linux (x86_64, arm64) — no Python or `pip` required
   - New `sync.spec` PyInstaller spec file for reproducible builds
@@ -15,17 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated README with binary download and usage instructions
 - 🍺 **Homebrew Formula**: Added `Formula/social-sync.rb` for easy installation via Homebrew on macOS and Linux
   - Install with `brew tap hossain-khan/social-sync && brew install social-sync`
-  - Formula uses platform-specific pre-built binaries (macOS arm64/x86_64, Linux x86_64)
+  - Formula supports platform-specific pre-built binaries (macOS arm64/x86_64, Linux x86_64/arm64)
+  - Formula version and sha256 checksums are auto-updated by CI after each release
   - Includes `brew test` that verifies `social-sync --help` runs successfully
 
-### Changed
-
 ### Fixed
-- 🔧 **Build binaries workflow Node.js 24 migration**: Updated `.github/workflows/build-binaries.yml` to use Node.js 24-compatible GitHub Actions versions: `actions/checkout@v6`, `actions/setup-python@v6`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`
-
-### Removed
-
-### Security
+- 🔧 **Build binaries workflow updates**: Updated `.github/workflows/build-binaries.yml` with Node.js 24-compatible GitHub Actions versions (`actions/checkout@v6`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`, `softprops/action-gh-release@v3`), fixed tag glob pattern, replaced deprecated `macos-13` runner with `macos-15-intel`, added Linux arm64 build target (`ubuntu-24.04-arm`), and wired `workflow_dispatch` tag input into checkout and release job
 
 ## [0.8.2] - 2025-12-31
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "social-sync"
-version = "0.8.2"
+version = "0.9.0"
 description = "Cross-platform social media synchronization tool for Bluesky and Mastodon"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/social_sync/__init__.py
+++ b/src/social_sync/__init__.py
@@ -6,7 +6,7 @@ maintaining conversation threading and providing comprehensive
 operational visibility.
 """
 
-__version__ = "0.8.2"
+__version__ = "0.9.0"
 __author__ = "Hossain Khan"
 __email__ = "hello@hossain.dev"
 __license__ = "MIT"


### PR DESCRIPTION
## Release 0.9.0

### What's included

#### Added
- 📦 **Standalone Binary Distribution** via PyInstaller — pre-built binaries for macOS (arm64, x86_64) and Linux (x86_64, arm64)
- 🍺 **Homebrew Formula** (`Formula/social-sync.rb`) — `brew tap hossain-khan/social-sync && brew install social-sync`
  - Supports all 4 platforms including Linux arm64
  - Version and sha256 auto-updated by CI after each tag release

#### Fixed
- 🔧 **Build binaries workflow overhaul**:
  - Updated all GitHub Actions to Node.js 24-compatible versions (`checkout@v6`, `upload-artifact@v7`, `download-artifact@v8`, `action-gh-release@v3`)
  - Fixed tag glob pattern (`[0-9]*` instead of `[0-9]+`)
  - Replaced deprecated `macos-13` runner with `macos-15-intel`
  - Added Linux arm64 build target (`ubuntu-24.04-arm`)
  - Wired `workflow_dispatch` tag input into checkout and release job
  - New `update-formula` job auto-commits sha256 checksums to main after release

### Pre-release checklist
- [x] Version bumped: `0.8.2` → `0.9.0` in `pyproject.toml` and `src/social_sync/__init__.py`
- [x] CHANGELOG updated: `[Unreleased]` moved to `[0.9.0] - 2026-04-12`
- [x] All 366 tests pass
- [x] Black, isort, mypy, flake8, bandit all clean

### After merge
Tag `0.9.0` on main to trigger the Build Release Binaries workflow.