### PR TITLE
✨ Fix setup command and error messages for standalone binary usage

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -164,15 +164,15 @@ def get_settings() -> Settings:
             if not env_file_exists:
                 raise ConfigurationError(
                     "Configuration file missing!\n\n"
-                    "To get started:\n"
-                    "1. Copy the example configuration file:\n"
-                    "   cp .env.example .env\n\n"
-                    "2. Edit .env with your credentials:\n"
+                    "To get started, run the setup command:\n"
+                    "   social-sync setup\n\n"
+                    "This will create a .env file that you can fill with your credentials:\n"
                     "   - Set your Bluesky handle and app password\n"
                     "   - Set your Mastodon instance URL and access token\n"
                     "   - Optionally configure sync settings\n\n"
                     "3. Run the command again\n\n"
-                    "For detailed setup instructions, see: docs/SETUP.md"
+                    "For detailed setup instructions, see:\n"
+                    "   https://github.com/hossain-khan/social-sync/blob/main/docs/SETUP.md"
                 ) from e
             else:
                 raise ConfigurationError(
@@ -182,7 +182,8 @@ def get_settings() -> Settings:
                     "- BLUESKY_HANDLE (your Bluesky handle)\n"
                     "- BLUESKY_PASSWORD (your Bluesky app password)\n"
                     "- MASTODON_ACCESS_TOKEN (your Mastodon access token)\n\n"
-                    "For detailed setup instructions, see: docs/SETUP.md\n\n"
+                    "For detailed setup instructions, see:\n"
+                    "   https://github.com/hossain-khan/social-sync/blob/main/docs/SETUP.md\n\n"
                     f"Original error: {e}"
                 ) from e
 

--- a/sync.py
+++ b/sync.py
@@ -27,6 +27,53 @@ try:
 except ImportError:
     __version__ = "unknown"
 
+# Template used by the `setup` command — embedded so it works in standalone binaries
+# (no dependency on .env.example being present on disk)
+ENV_TEMPLATE = """\
+# Environment variables for Social Sync
+# Fill in your credentials below
+
+# Bluesky Credentials
+BLUESKY_HANDLE=your-handle.bsky.social
+BLUESKY_PASSWORD=your-app-password
+
+# Mastodon Credentials
+MASTODON_API_BASE_URL=https://mastodon.social
+MASTODON_ACCESS_TOKEN=your-access-token
+
+# Sync Configuration
+SYNC_INTERVAL_MINUTES=60
+MAX_POSTS_PER_SYNC=10
+# Start date for syncing posts (ISO format). If not set, starts from 7 days ago
+# Examples:
+#   SYNC_START_DATE=2025-01-01
+#   SYNC_START_DATE=2025-01-15T10:30:00
+#   SYNC_START_DATE=2025-01-15T10:30:00-05:00
+# SYNC_START_DATE=2025-01-01
+# SYNC_CONTENT_WARNINGS=true
+DRY_RUN=true
+# DISABLE_SOURCE_PLATFORM=false
+
+# Video Sync Settings
+SYNC_VIDEOS=false
+MAX_VIDEO_SIZE_MB=40
+
+# Media Upload Failure Handling
+IMAGE_UPLOAD_FAILURE_STRATEGY=partial
+IMAGE_UPLOAD_MAX_RETRIES=3
+
+# Logging
+LOG_LEVEL=INFO
+"""
+
+
+def _cli_name() -> str:
+    """Return the name to use in usage hints (binary name or 'python sync.py')."""
+    if getattr(sys, "frozen", False):
+        return Path(sys.argv[0]).name
+    return "python sync.py"
+
+
 # Load environment variables
 load_dotenv()
 
@@ -178,22 +225,15 @@ def setup():
                 "⚠️  .env file already exists. Do you want to overwrite it?"
             ):
                 click.echo(
-                    "Setup cancelled. Use 'python sync.py config' to view current configuration."
+                    f"Setup cancelled. Use '{_cli_name()} config' to view current configuration."
                 )
                 return
 
-        # Copy .env.example to .env
-        example_path = Path(".env.example")
-        if not example_path.exists():
-            click.echo("❌ Error: .env.example file not found!")
-            sys.exit(1)
+        # Write the embedded template (works even in standalone binary — no .env.example needed)
+        env_path.write_text(ENV_TEMPLATE)
+        click.echo("✅ Created .env configuration file")
 
-        # Copy the example file
-        import shutil
-
-        shutil.copy2(example_path, env_path)
-        click.echo("✅ Created .env file from .env.example")
-
+        cli = _cli_name()
         click.echo("\n📝 Next steps:")
         click.echo("1. Edit the .env file with your credentials:")
         click.echo("   - BLUESKY_HANDLE: Your Bluesky handle (e.g., user.bsky.social)")
@@ -201,10 +241,13 @@ def setup():
         click.echo("   - MASTODON_ACCESS_TOKEN: Your Mastodon access token")
         click.echo("   - MASTODON_API_BASE_URL: Your Mastodon instance URL")
         click.echo("\n2. Test your configuration:")
-        click.echo("   python sync.py test")
+        click.echo(f"   {cli} test")
         click.echo("\n3. Run your first sync:")
-        click.echo("   python sync.py sync --dry-run")
-        click.echo("\n📖 For detailed setup instructions, see: docs/SETUP.md")
+        click.echo(f"   {cli} sync --dry-run")
+        click.echo("\n📖 For detailed setup instructions, see:")
+        click.echo(
+            "   https://github.com/hossain-khan/social-sync/blob/main/docs/SETUP.md"
+        )
 
         # Offer to open the file for editing
         if click.confirm("\n🔧 Would you like to open .env for editing now?"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ from click.testing import CliRunner
 
 # Import the CLI group from sync.py
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from sync import cli
+from sync import ENV_TEMPLATE, _cli_name, cli
 
 
 class TestCLI:
@@ -442,3 +442,114 @@ class TestCLIIntegration:
         # This would test actual file I/O operations
         # Requires more setup but is valuable for integration testing
         pass
+
+
+class TestEnvTemplate:
+    """Tests for the embedded ENV_TEMPLATE constant."""
+
+    def test_env_template_contains_required_keys(self):
+        """ENV_TEMPLATE must include all required credential keys."""
+        required = [
+            "BLUESKY_HANDLE",
+            "BLUESKY_PASSWORD",
+            "MASTODON_API_BASE_URL",
+            "MASTODON_ACCESS_TOKEN",
+        ]
+        for key in required:
+            assert key in ENV_TEMPLATE, f"{key} missing from ENV_TEMPLATE"
+
+    def test_env_template_contains_common_settings(self):
+        """ENV_TEMPLATE should include common optional settings."""
+        for key in (
+            "SYNC_INTERVAL_MINUTES",
+            "MAX_POSTS_PER_SYNC",
+            "DRY_RUN",
+            "LOG_LEVEL",
+        ):
+            assert key in ENV_TEMPLATE, f"{key} missing from ENV_TEMPLATE"
+
+    def test_env_template_is_non_empty_string(self):
+        assert isinstance(ENV_TEMPLATE, str) and len(ENV_TEMPLATE) > 0
+
+
+class TestCliName:
+    """Tests for the _cli_name() helper."""
+
+    def test_cli_name_returns_string(self):
+        assert isinstance(_cli_name(), str)
+
+    def test_cli_name_not_frozen(self):
+        """When not frozen (normal Python), returns 'python sync.py'."""
+        with patch("sys.frozen", False, create=True):
+            assert _cli_name() == "python sync.py"
+
+    def test_cli_name_frozen(self):
+        """When frozen (PyInstaller binary), returns the executable filename."""
+        with patch.object(sys, "frozen", True, create=True):
+            with patch.object(sys, "argv", ["/home/user/tools/social-sync", "setup"]):
+                assert _cli_name() == "social-sync"
+
+
+class TestSetupCommand:
+    """Tests for the `setup` CLI command in standalone / no-repo mode."""
+
+    def test_setup_creates_env_file(self):
+        """setup writes a .env file from the embedded template."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli, ["setup"], input="n\n")
+            assert result.exit_code == 0, result.output
+            assert Path(".env").exists()
+
+    def test_setup_env_file_contains_required_keys(self):
+        """The .env file written by setup must contain required credential keys."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["setup"], input="n\n")
+            content = Path(".env").read_text()
+            for key in (
+                "BLUESKY_HANDLE",
+                "BLUESKY_PASSWORD",
+                "MASTODON_ACCESS_TOKEN",
+                "MASTODON_API_BASE_URL",
+            ):
+                assert key in content
+
+    def test_setup_does_not_require_env_example(self):
+        """setup must succeed even when .env.example is absent (standalone mode)."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            assert not Path(".env.example").exists()
+            result = runner.invoke(cli, ["setup"], input="n\n")
+            assert result.exit_code == 0
+            assert "Error" not in result.output
+
+    def test_setup_prompts_before_overwrite(self):
+        """setup asks for confirmation when .env already exists."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path(".env").write_text("EXISTING=1\n")
+            result = runner.invoke(cli, ["setup"], input="n\n")  # decline overwrite
+            assert result.exit_code == 0
+            assert "already exists" in result.output
+            # Original file must be untouched
+            assert Path(".env").read_text() == "EXISTING=1\n"
+
+    def test_setup_overwrites_on_confirm(self):
+        """setup replaces .env when the user confirms."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path(".env").write_text("EXISTING=1\n")
+            result = runner.invoke(
+                cli, ["setup"], input="y\nn\n"
+            )  # confirm overwrite, skip editor
+            assert result.exit_code == 0
+            content = Path(".env").read_text()
+            assert "BLUESKY_HANDLE" in content
+
+    def test_setup_shows_github_url(self):
+        """Hint shown after setup must point to the GitHub docs URL."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli, ["setup"], input="n\n")
+            assert "github.com/hossain-khan/social-sync" in result.output

--- a/tests/test_config_additional.py
+++ b/tests/test_config_additional.py
@@ -124,7 +124,7 @@ class TestConfigurationEdgeCases:
 
                 error_msg = str(exc_info.value)
                 assert "Configuration file missing" in error_msg
-                assert "cp .env.example .env" in error_msg
+                assert "social-sync setup" in error_msg
             finally:
                 os.chdir(original_cwd)
 


### PR DESCRIPTION
## Problem

When using the standalone binary (downloaded from GitHub Releases), the `setup` and `config` commands failed because they assumed the tool was running from a cloned repo:

```
$ ./social-sync setup
🚀 Welcome to Social Sync Setup!
❌ Error: .env.example file not found!

$ ./social-sync config
❌ Configuration file missing!
   cp .env.example .env       # .env.example doesn't exist standalone
   see: docs/SETUP.md         # docs/ folder doesn't exist standalone
```

## Fix

### `sync.py` — `setup` command
- Embedded the `.env` template as an `ENV_TEMPLATE` string constant — no longer reads `.env.example` from disk
- `setup` now writes the embedded template directly, works in standalone binary mode
- Added `_cli_name()` helper: detects `sys.frozen` (PyInstaller) to show the right invocation (`./social-sync` vs `python sync.py`) in "next steps"
- Replaced `docs/SETUP.md` reference with the full GitHub URL

### `src/config.py` — error messages
- Replaced `cp .env.example .env` instruction with `social-sync setup` command
- Replaced `docs/SETUP.md` with the full GitHub URL

### `tests/test_config_additional.py`
- Updated assertion to match new error message text (`social-sync setup` instead of `cp .env.example .env`)

## Result

```
$ ./social-sync setup
🚀 Welcome to Social Sync Setup!
✅ Created .env configuration file

📝 Next steps:
1. Edit the .env file with your credentials:
   ...
2. Test your configuration:
   social-sync test
3. Run your first sync:
   social-sync sync --dry-run

📖 For detailed setup instructions, see:
   https://github.com/hossain-khan/social-sync/blob/main/docs/SETUP.md
```

All 366 tests pass.