### PR TITLE
🏗️ Prepare release 0.9.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.9.2] - 2026-04-12
+
+### Added
+- ✨ **Standalone-friendly `setup` command**: `setup` now works without a cloned repository
+  - Embedded a complete `.env` template inside the binary — no longer copies `.env.example` from disk
+  - `setup` creates a ready-to-edit `.env` file in the current directory when run from the standalone binary
+  - `_cli_name()` detects PyInstaller (`sys.frozen`) and shows the correct invocation (`./social-sync` vs `python sync.py`) in next-step hints
+  - Setup hints now link to the GitHub docs URL instead of the local `docs/SETUP.md` path
+
+### Fixed
+- 🐛 **Error messages for missing configuration now guide standalone users**: `config`, `sync`, `test`, and `status` commands previously told users to `cp .env.example .env` and read `docs/SETUP.md` — neither exists in standalone installs
+  - Error messages now say `social-sync setup` (runnable in any mode)
+  - Documentation links now point to the full GitHub URL
+
 ## [0.9.1] - 2026-04-12
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "social-sync"
-version = "0.9.1"
+version = "0.9.2"
 description = "Cross-platform social media synchronization tool for Bluesky and Mastodon"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/social_sync/__init__.py
+++ b/src/social_sync/__init__.py
@@ -6,7 +6,7 @@ maintaining conversation threading and providing comprehensive
 operational visibility.
 """
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 __author__ = "Hossain Khan"
 __email__ = "hello@hossain.dev"
 __license__ = "MIT"


### PR DESCRIPTION
## Release 0.9.2

Patch release shipping the standalone-binary `setup` improvements from PR #129.

### Changes

**Added**
- `setup` command no longer requires `.env.example` on disk — the complete `.env` template is now embedded in the binary itself
- `_cli_name()` detects PyInstaller (`sys.frozen`) and shows the correct invocation (`./social-sync` vs `python sync.py`) in next-step hints
- Setup hints link to the GitHub docs URL instead of the local `docs/SETUP.md` path

**Fixed**
- `config`, `sync`, `test`, and `status` error messages now say `social-sync setup` instead of `cp .env.example .env`, and point to the GitHub URL instead of the local `docs/SETUP.md`

### Quality Checks
378 tests pass; Black, isort, mypy, flake8, bandit, and pip-audit all clean.