### PR TITLE
fix: correct Homebrew tap instruction with explicit repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A Python-based tool to automatically sync posts from Bluesky to Mastodon with Gi
 The easiest way to install Social Sync on macOS or Linux (x86_64) is via [Homebrew](https://brew.sh):
 
 ```bash
-brew tap hossain-khan/social-sync
+brew tap hossain-khan/social-sync https://github.com/hossain-khan/social-sync.git
 brew install social-sync
 ```
 


### PR DESCRIPTION
## Description

Fixes the Homebrew tap instruction that was failing for users due to incorrect repository naming convention.

## Problem

The short-form `brew tap hossain-khan/social-sync` fails because Homebrew expects a repository named `homebrew-social-sync` by convention. Since the formula is in the main `social-sync` repository (not a separate `homebrew-social-sync` repo), users need to provide the explicit Git URL.

Error that users were encountering:
```
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/hossain-khan/homebrew-social-sync/'
```

## Solution

Updated README.md to show the correct tap command with the explicit repository URL:
```bash
brew tap hossain-khan/social-sync https://github.com/hossain-khan/social-sync.git
brew install social-sync
```

This tells Homebrew the exact Git URL to clone for the tap, working around the naming convention issue.

## Fixes

Closes #131