### PR TITLE
refactor: clean up tests to adhere to pytest best practices

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -232,7 +232,7 @@ jobs:
           MASTODON_API_BASE_URL: https://mastodon.social
         run: |
           echo "🔗 Running integration tests..."
-          python tests/test_integration.py
+          python -m pytest tests/test_integration.py
           echo "✅ Integration tests completed"
           
       - name: Run threading tests
@@ -243,7 +243,7 @@ jobs:
           MASTODON_API_BASE_URL: https://mastodon.social
         run: |
           echo "🧵 Running threading tests..."
-          python tests/test_threading.py
+          python -m pytest tests/test_threading.py
           echo "✅ Threading tests completed"
       
       - name: Validate sync dry-run

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [tool:pytest]
+pythonpath = .
 testpaths = tests
 python_files = test_*.py
 python_classes = Test*

--- a/tests/test_bluesky_client.py
+++ b/tests/test_bluesky_client.py
@@ -2,15 +2,8 @@
 Tests for Bluesky Client
 """
 
-import sys
 from datetime import datetime, timezone
-from pathlib import Path
 from unittest.mock import Mock, patch
-
-# Add the parent directory to sys.path to import src as a package
-project_root = Path(__file__).parent.parent
-if str(project_root) not in sys.path:
-    sys.path.insert(0, str(project_root))
 
 from src.bluesky_client import BlueskyClient, BlueskyFetchResult, BlueskyPost
 

--- a/tests/test_bluesky_client_additional.py
+++ b/tests/test_bluesky_client_additional.py
@@ -2,17 +2,10 @@
 Additional tests for Bluesky Client module to improve coverage
 """
 
-import sys
 from datetime import datetime, timezone
-from pathlib import Path
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
-
-# Add the parent directory to sys.path to import src as a package
-project_root = Path(__file__).parent.parent
-if str(project_root) not in sys.path:
-    sys.path.insert(0, str(project_root))
 
 from src.bluesky_client import BlueskyClient, BlueskyFetchResult, BlueskyPost
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,95 +3,51 @@ Tests for CLI Interface
 """
 
 import os
-import subprocess
 import sys
-import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 from click.testing import CliRunner
-
-# Import the CLI group from sync.py
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from sync import ENV_TEMPLATE, _cli_name, cli
 
 
-class TestCLI:
-    """Test suite for CLI interface"""
+def test_cli_help_command():
+    """Test CLI help command works"""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "Social Sync" in result.output or "Usage:" in result.output
 
-    def test_cli_help_command(self):
-        """Test CLI help command works"""
-        result = subprocess.run(
-            [sys.executable, str(Path(__file__).parent.parent / "sync.py"), "--help"],
-            capture_output=True,
-            text=True,
-        )
 
-        assert result.returncode == 0
-        assert "Social Sync" in result.stdout or "Usage:" in result.stdout
+def test_cli_sync_command_help():
+    """Test sync subcommand help"""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["sync", "--help"])
+    assert result.exit_code == 0
+    assert "--dry-run" in result.output
+    assert "--since-date" in result.output
+    assert "--disable-source-platform" in result.output
 
-    def test_cli_sync_command_help(self):
-        """Test sync subcommand help"""
-        result = subprocess.run(
-            [
-                sys.executable,
-                str(Path(__file__).parent.parent / "sync.py"),
-                "sync",
-                "--help",
-            ],
-            capture_output=True,
-            text=True,
-        )
 
-        assert result.returncode == 0
-        assert "--dry-run" in result.stdout
-        assert "--since-date" in result.stdout
-        assert "--disable-source-platform" in result.stdout
+def test_cli_status_command_help():
+    """Test status subcommand help"""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["status", "--help"])
+    assert result.exit_code == 0
 
-    def test_cli_status_command_help(self):
-        """Test status subcommand help"""
-        result = subprocess.run(
-            [
-                sys.executable,
-                str(Path(__file__).parent.parent / "sync.py"),
-                "status",
-                "--help",
-            ],
-            capture_output=True,
-            text=True,
-        )
 
-        assert result.returncode == 0
+def test_cli_config_command_help():
+    """Test config subcommand help"""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "--help"])
+    assert result.exit_code == 0
 
-    def test_cli_config_command_help(self):
-        """Test config subcommand help"""
-        result = subprocess.run(
-            [
-                sys.executable,
-                str(Path(__file__).parent.parent / "sync.py"),
-                "config",
-                "--help",
-            ],
-            capture_output=True,
-            text=True,
-        )
 
-        assert result.returncode == 0
-
-    def test_cli_test_command_help(self):
-        """Test test subcommand help"""
-        result = subprocess.run(
-            [
-                sys.executable,
-                str(Path(__file__).parent.parent / "sync.py"),
-                "test",
-                "--help",
-            ],
-            capture_output=True,
-            text=True,
-        )
-
-        assert result.returncode == 0
+def test_cli_test_command_help():
+    """Test test subcommand help"""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["test", "--help"])
+    assert result.exit_code == 0
 
 
 def test_sync_command_dry_run():
@@ -412,36 +368,6 @@ def test_cli_log_level_option():
     result = runner.invoke(cli, ["--log-level", "DEBUG", "--help"])
 
     assert result.exit_code == 0
-
-
-class TestCLIIntegration:
-    """Integration tests for CLI with real file operations"""
-
-    def setup_method(self):
-        """Set up temporary directory for integration tests"""
-        self.temp_dir = tempfile.mkdtemp()
-        self.original_cwd = os.getcwd()
-        os.chdir(self.temp_dir)
-
-    def teardown_method(self):
-        """Clean up temporary directory"""
-        os.chdir(self.original_cwd)
-        # Clean up temp directory
-        import shutil
-
-        shutil.rmtree(self.temp_dir)
-
-    def test_cli_creates_log_file(self):
-        """Test that CLI creates log file"""
-        # This would require more complex mocking or actual credentials
-        # For now, we'll test the simpler case
-        pass
-
-    def test_cli_state_file_handling(self):
-        """Test CLI handles state file correctly"""
-        # This would test actual file I/O operations
-        # Requires more setup but is valuable for integration testing
-        pass
 
 
 class TestEnvTemplate:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,18 +3,11 @@ Tests for Configuration Management
 """
 
 import os
-import sys
 import time
 from datetime import datetime, timezone
-from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
-
-# Add the parent directory to sys.path to import src as a package
-project_root = Path(__file__).parent.parent
-if str(project_root) not in sys.path:
-    sys.path.insert(0, str(project_root))
 
 from src.config import Settings
 

--- a/tests/test_config_additional.py
+++ b/tests/test_config_additional.py
@@ -3,18 +3,11 @@ Additional tests for Configuration module to improve coverage
 """
 
 import os
-import sys
 import tempfile
 from datetime import datetime
-from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
-
-# Add the parent directory to sys.path to import src as a package
-project_root = Path(__file__).parent.parent
-if str(project_root) not in sys.path:
-    sys.path.insert(0, str(project_root))
 
 from src.config import ConfigurationError, Settings, check_env_file_exists, get_settings
 

--- a/tests/test_content_processor.py
+++ b/tests/test_content_processor.py
@@ -2,14 +2,7 @@
 Tests for Content Processor
 """
 
-import sys
-from pathlib import Path
 from unittest.mock import Mock, patch
-
-# Add the parent directory to sys.path to import src as a package
-project_root = Path(__file__).parent.parent
-if str(project_root) not in sys.path:
-    sys.path.insert(0, str(project_root))
 
 from src.content_processor import ContentProcessor
 

--- a/tests/test_content_processor_additional.py
+++ b/tests/test_content_processor_additional.py
@@ -2,14 +2,7 @@
 Additional tests for ContentProcessor module to improve coverage
 """
 
-import sys
-from pathlib import Path
 from unittest.mock import Mock, patch
-
-# Add the parent directory to sys.path to import src as a package
-project_root = Path(__file__).parent.parent
-if str(project_root) not in sys.path:
-    sys.path.insert(0, str(project_root))
 
 from src.content_processor import ContentProcessor
 

--- a/tests/test_filtered_posts_persistence.py
+++ b/tests/test_filtered_posts_persistence.py
@@ -3,14 +3,8 @@ Tests for filtered posts persistence to skipped_posts audit trail
 """
 
 import json
-import sys
-import tempfile
 from datetime import datetime
-from pathlib import Path
 from unittest.mock import Mock, patch
-
-# Add the parent directory to sys.path to import src as a package
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import pytest
 
@@ -23,22 +17,19 @@ class TestFilteredPostsPersistence:
     """Test that filtered posts are persisted to skipped_posts with correct reasons"""
 
     @pytest.fixture
-    def temp_state_file(self):
+    def temp_state_file(self, tmp_path):
         """Create a temporary sync state file for testing"""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
-            temp_file = tmp.name
-            initial_state = {
-                "last_sync_time": "2025-12-26T00:00:00.000000",
-                "synced_posts": [],
-                "last_bluesky_post_uri": None,
-                "skipped_posts": [],
-            }
-            json.dump(initial_state, tmp)
+        temp_file = tmp_path / "sync_state.json"
+        initial_state = {
+            "last_sync_time": "2025-12-26T00:00:00.000000",
+            "synced_posts": [],
+            "last_bluesky_post_uri": None,
+            "skipped_posts": [],
+        }
+        with open(temp_file, "w") as f:
+            json.dump(initial_state, f)
 
-        yield temp_file
-
-        # Cleanup
-        Path(temp_file).unlink()
+        return str(temp_file)
 
     def test_bluesky_client_tracks_reply_filtering(self):
         """Test that BlueskyClient tracks filtered reply posts in result"""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,14 +6,10 @@ They use mocked external dependencies but test real integration between internal
 """
 
 import os
-import sys
-import tempfile
 from datetime import datetime
-from pathlib import Path
 from unittest.mock import Mock, patch
 
-# Add src to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent))
+import pytest
 
 from src.bluesky_client import BlueskyFetchResult
 from src.config import Settings
@@ -24,16 +20,11 @@ from src.sync_state import SyncState
 class TestSyncIntegration:
     """Integration tests for sync workflow"""
 
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup_state(self, tmp_path):
         """Set up integration test environment"""
-        self.temp_dir = tempfile.mkdtemp()
+        self.temp_dir = str(tmp_path)
         self.state_file = os.path.join(self.temp_dir, "test_sync_state.json")
-
-    def teardown_method(self):
-        """Clean up test environment"""
-        import shutil
-
-        shutil.rmtree(self.temp_dir)
 
     @patch("src.sync_orchestrator.BlueskyClient")
     @patch("src.sync_orchestrator.MastodonClient")
@@ -128,7 +119,6 @@ class TestContentProcessingIntegration:
 
     def setup_method(self):
         """Set up content processing tests"""
-        sys.path.insert(0, str(Path(__file__).parent.parent))
         from src.content_processor import ContentProcessor
 
         self.processor = ContentProcessor()
@@ -186,19 +176,3 @@ class TestContentProcessingIntegration:
         # Should be truncated to fit within 500 chars
         assert len(with_attribution) <= 500
         assert with_attribution.endswith("(via Bluesky 🦋)")
-
-
-if __name__ == "__main__":
-    # Simple test runner for integration tests
-    import unittest
-
-    # Discover and run tests
-    loader = unittest.TestLoader()
-    start_dir = os.path.dirname(__file__)
-    suite = loader.discover(start_dir, pattern="test_integration.py")
-
-    runner = unittest.TextTestRunner(verbosity=2)
-    result = runner.run(suite)
-
-    # Exit with appropriate code
-    exit(0 if result.wasSuccessful() else 1)

--- a/tests/test_mastodon_client_additional.py
+++ b/tests/test_mastodon_client_additional.py
@@ -2,17 +2,10 @@
 Additional tests for Mastodon Client module to improve coverage
 """
 
-import sys
 from datetime import datetime
-from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
-
-# Add the parent directory to sys.path to import src as a package
-project_root = Path(__file__).parent.parent
-if str(project_root) not in sys.path:
-    sys.path.insert(0, str(project_root))
 
 from src.mastodon_client import MastodonClient, MastodonPost
 

--- a/tests/test_sync_state.py
+++ b/tests/test_sync_state.py
@@ -4,15 +4,9 @@ Tests for Sync State Management
 
 import json
 import os
-import sys
-import tempfile
 from datetime import datetime
-from pathlib import Path
 
-# Add the parent directory to sys.path to import src as a package
-project_root = Path(__file__).parent.parent
-if str(project_root) not in sys.path:
-    sys.path.insert(0, str(project_root))
+import pytest
 
 from src.sync_state import SyncState
 
@@ -20,20 +14,11 @@ from src.sync_state import SyncState
 class TestSyncState:
     """Test suite for SyncState class"""
 
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup_state(self, tmp_path):
         """Set up test fixtures with temporary state file"""
-        # Create temporary file for state
-        self.temp_file = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        )
-        self.temp_file.close()
-        self.state_file_path = self.temp_file.name
+        self.state_file_path = str(tmp_path / "sync_state.json")
         self.sync_state = SyncState(self.state_file_path)
-
-    def teardown_method(self):
-        """Clean up test fixtures"""
-        if os.path.exists(self.state_file_path):
-            os.unlink(self.state_file_path)
 
     def test_init_new_state_file(self):
         """Test initialization with non-existent state file"""

--- a/tests/test_sync_state_additional.py
+++ b/tests/test_sync_state_additional.py
@@ -4,18 +4,10 @@ Additional tests for SyncState module to improve coverage
 
 import json
 import os
-import sys
-import tempfile
 import time
 from datetime import datetime, timedelta
-from pathlib import Path
 
 import pytest
-
-# Add the parent directory to sys.path to import src as a package
-project_root = Path(__file__).parent.parent
-if str(project_root) not in sys.path:
-    sys.path.insert(0, str(project_root))
 
 from src.sync_state import SyncState
 
@@ -23,16 +15,11 @@ from src.sync_state import SyncState
 class TestSyncStateEdgeCases:
     """Additional tests for SyncState edge cases to improve coverage"""
 
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup_state(self, tmp_path):
         """Set up test fixtures"""
-        self.temp_dir = tempfile.mkdtemp()
+        self.temp_dir = str(tmp_path)
         self.state_file_path = os.path.join(self.temp_dir, "test_state.json")
-
-    def teardown_method(self):
-        """Clean up test fixtures"""
-        import shutil
-
-        shutil.rmtree(self.temp_dir)
 
     def test_corrupted_json_file_recovery(self):
         """Test that SyncState recovers gracefully from corrupted JSON files"""

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -6,14 +6,10 @@ including reply detection, parent post lookup, and Mastodon reply posting.
 """
 
 import os
-import sys
-import tempfile
 from datetime import datetime
-from pathlib import Path
 from unittest.mock import Mock, patch
 
-# Add src to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent))
+import pytest
 
 from src.bluesky_client import BlueskyPost
 from src.sync_orchestrator import SocialSyncOrchestrator
@@ -23,16 +19,11 @@ from src.sync_state import SyncState
 class TestThreadingSyncFlow:
     """Test threading functionality in sync workflow"""
 
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup_state(self, tmp_path):
         """Set up threading test environment"""
-        self.temp_dir = tempfile.mkdtemp()
+        self.temp_dir = str(tmp_path)
         self.state_file = os.path.join(self.temp_dir, "threading_test_state.json")
-
-    def teardown_method(self):
-        """Clean up test environment"""
-        import shutil
-
-        shutil.rmtree(self.temp_dir)
 
     @patch("src.sync_orchestrator.BlueskyClient")
     @patch("src.sync_orchestrator.MastodonClient")
@@ -416,51 +407,29 @@ class TestThreadingEdgeCases:
 
         assert regular_post.reply_to is None
 
-    def test_sync_state_thread_mappings(self):
+    def test_sync_state_thread_mappings(self, tmp_path):
         """Test sync state handles thread mappings correctly"""
-        temp_file = tempfile.NamedTemporaryFile(delete=False)
-        temp_file.close()
+        state_file = tmp_path / "thread_mapping_test.json"
+        sync_state = SyncState(state_file)
 
-        try:
-            sync_state = SyncState(temp_file.name)
+        # Add thread: parent -> reply1 -> reply2
+        sync_state.mark_post_synced("at://parent", "mastodon-parent")
+        sync_state.mark_post_synced("at://reply1", "mastodon-reply1")
+        sync_state.mark_post_synced("at://reply2", "mastodon-reply2")
 
-            # Add thread: parent -> reply1 -> reply2
-            sync_state.mark_post_synced("at://parent", "mastodon-parent")
-            sync_state.mark_post_synced("at://reply1", "mastodon-reply1")
-            sync_state.mark_post_synced("at://reply2", "mastodon-reply2")
+        # Verify all mappings exist
+        assert (
+            sync_state.get_mastodon_id_for_bluesky_post("at://parent")
+            == "mastodon-parent"
+        )
+        assert (
+            sync_state.get_mastodon_id_for_bluesky_post("at://reply1")
+            == "mastodon-reply1"
+        )
+        assert (
+            sync_state.get_mastodon_id_for_bluesky_post("at://reply2")
+            == "mastodon-reply2"
+        )
 
-            # Verify all mappings exist
-            assert (
-                sync_state.get_mastodon_id_for_bluesky_post("at://parent")
-                == "mastodon-parent"
-            )
-            assert (
-                sync_state.get_mastodon_id_for_bluesky_post("at://reply1")
-                == "mastodon-reply1"
-            )
-            assert (
-                sync_state.get_mastodon_id_for_bluesky_post("at://reply2")
-                == "mastodon-reply2"
-            )
-
-            # Verify count
-            assert sync_state.get_synced_posts_count() == 3
-
-        finally:
-            os.unlink(temp_file.name)
-
-
-if __name__ == "__main__":
-    # Simple test runner for threading tests
-    import unittest
-
-    # Discover and run tests
-    loader = unittest.TestLoader()
-    start_dir = os.path.dirname(__file__)
-    suite = loader.discover(start_dir, pattern="test_threading.py")
-
-    runner = unittest.TextTestRunner(verbosity=2)
-    result = runner.run(suite)
-
-    # Exit with appropriate code
-    exit(0 if result.wasSuccessful() else 1)
+        # Verify count
+        assert sync_state.get_synced_posts_count() == 3


### PR DESCRIPTION
1. Removed Manual Path-Hacking: Added  pythonpath = .  to [pytest.ini](file:///Users/hossain/dev/repos/cli-apps/social-sync/pytest.ini) and removed the legacy  sys.path.insert(0, ...)  boilerplate across all test files.
  2. Replaced Manual Temp Management: Rewrote setup/teardowns to use pytest's built-in  tmp_path  fixture, removing standard library  tempfile  and manual
  directory cleanups.
  3. Consolidated CLI Tests: Refactored the subprocess-based help tests to use Click's in-process  CliRunner  for faster, isolated test runs.
  4. Normalized Class Groups: Unpacked mixed-style test classes (like  TestCLI ) into top-level functions to keep them consistent with the rest of the test
  suite.
  5. Removed Dead Code: Deleted the unused, empty  TestCLIIntegration  stub.

  ### 🧪 Validation:

  All code quality checks were executed and successfully passed:

  • pytest: 100% tests passing (378 passed, 3 skipped)
  • mypy & pyrefly: 0 type checking errors
  • black & isort: Code successfully formatted
  • flake8 & bandit: 0 linting and security issues