### PR TITLE
Fix metadata hydration in BlueskyClient & increase unit test coverage

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -59,9 +59,13 @@ def run_integration_tests():
     print("🔗 Running Integration Tests...")
     print("=" * 30)
 
+    # Set up environment for tests
+    project_root = Path(__file__).parent
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(project_root)
     # Run integration tests
-    cmd = [sys.executable, "test_integration.py"]
-    result = subprocess.run(cmd)
+    cmd = [sys.executable, "tests/test_integration.py"]
+    result = subprocess.run(cmd, env=env)
 
     if result.returncode == 0:
         print("✅ Integration tests passed!")
@@ -76,9 +80,13 @@ def run_threading_tests():
     print("🧵 Running Threading Tests...")
     print("=" * 30)
 
+    # Set up environment for tests
+    project_root = Path(__file__).parent
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(project_root)
     # Run threading tests
-    cmd = [sys.executable, "test_threading.py"]
-    result = subprocess.run(cmd)
+    cmd = [sys.executable, "tests/test_threading.py"]
+    result = subprocess.run(cmd, env=env)
 
     if result.returncode == 0:
         print("✅ Threading tests passed!")

--- a/src/bluesky_client.py
+++ b/src/bluesky_client.py
@@ -202,16 +202,16 @@ class BlueskyClient:
 
                 # Track and skip quote posts of other people's content
                 # Allow self-quotes (quoting own posts) but filter quotes of others
-                if hasattr(post.record, "embed") and post.record.embed:
-                    embed_type = getattr(post.record.embed, "py_type", None)
+                if hasattr(post, "embed") and post.embed:
+                    embed_type = getattr(post.embed, "py_type", None)
 
                     # Check if this is a quote post (app.bsky.embed.record)
                     if embed_type == "app.bsky.embed.record":
                         # Extract the quoted post URI
-                        if hasattr(post.record.embed, "record") and hasattr(
-                            post.record.embed.record, "uri"
+                        if hasattr(post.embed, "record") and hasattr(
+                            post.embed.record, "uri"
                         ):
-                            quoted_uri = post.record.embed.record.uri
+                            quoted_uri = post.embed.record.uri
                             quoted_did = self._extract_did_from_uri(quoted_uri)
 
                             # Skip if quoting someone else's post (allow self-quotes)
@@ -331,8 +331,8 @@ class BlueskyClient:
                     # Convert AT Protocol embed objects to dictionaries for cross-platform compatibility
                     # This ensures external links, images, etc. are preserved when syncing to Mastodon
                     embed=(
-                        BlueskyClient._extract_embed_data(post.record.embed)
-                        if hasattr(post.record, "embed") and post.record.embed
+                        BlueskyClient._extract_embed_data(post.embed)
+                        if hasattr(post, "embed") and post.embed
                         else None
                     ),
                     # Extract rich text features (hashtags, mentions, links) from AT Protocol facets

--- a/tests/test_bluesky_client.py
+++ b/tests/test_bluesky_client.py
@@ -121,7 +121,8 @@ class TestBlueskyClient:
         mock_post_record.text = "Test post content"
         mock_post_record.created_at = "2025-01-01T10:00:00.000Z"
         mock_post_record.facets = []
-        mock_post_record.embed = None
+        if hasattr(mock_post_record, "embed"):
+            delattr(mock_post_record, "embed")
         mock_post_record.reply = None
         mock_post_record.labels = None
         mock_post_record.langs = None
@@ -186,7 +187,8 @@ class TestBlueskyClient:
         mock_post_record.text = "This is a reply"
         mock_post_record.created_at = "2025-01-01T10:00:00.000Z"
         mock_post_record.facets = []
-        mock_post_record.embed = None
+        if hasattr(mock_post_record, "embed"):
+            delattr(mock_post_record, "embed")
         mock_post_record.reply = (
             mock_reply  # This should cause the post to be filtered out
         )
@@ -242,7 +244,8 @@ class TestBlueskyClient:
         mock_post_record.text = "This is a self-reply"
         mock_post_record.created_at = "2025-01-01T10:00:00.000Z"
         mock_post_record.facets = []
-        mock_post_record.embed = None
+        if hasattr(mock_post_record, "embed"):
+            delattr(mock_post_record, "embed")
         mock_post_record.reply = mock_reply
 
         mock_feed_item = Mock()
@@ -309,7 +312,8 @@ class TestBlueskyClient:
         mock_post_record.text = "Reply to my reply in someone else's thread"
         mock_post_record.created_at = "2025-01-01T10:00:00.000Z"
         mock_post_record.facets = []
-        mock_post_record.embed = None
+        if hasattr(mock_post_record, "embed"):
+            delattr(mock_post_record, "embed")
         mock_post_record.reply = mock_reply
 
         mock_feed_item = Mock()
@@ -370,7 +374,8 @@ class TestBlueskyClient:
         mock_post_record.text = "Deep nested reply in my own thread"
         mock_post_record.created_at = "2025-01-01T10:00:00.000Z"
         mock_post_record.facets = []
-        mock_post_record.embed = None
+        if hasattr(mock_post_record, "embed"):
+            delattr(mock_post_record, "embed")
         mock_post_record.reply = mock_reply
 
         mock_feed_item = Mock()
@@ -497,7 +502,8 @@ class TestBlueskyClient:
         mock_post_record.text = "Check this out"
         mock_post_record.created_at = "2025-01-01T10:00:00.000Z"
         mock_post_record.facets = []
-        mock_post_record.embed = mock_embed
+        if hasattr(mock_post_record, "embed"):
+            delattr(mock_post_record, "embed")
         mock_post_record.reply = None
         mock_post_record.labels = None
         mock_post_record.langs = None
@@ -511,6 +517,7 @@ class TestBlueskyClient:
         mock_feed_item.post.uri = "at://post-with-embed"
         mock_feed_item.post.cid = "embed-cid"
         mock_feed_item.post.record = mock_post_record
+        mock_feed_item.post.embed = mock_embed
         mock_feed_item.post.author = Mock()
         mock_feed_item.post.author.handle = "test.bsky.social"
         mock_feed_item.post.author.display_name = "Test User"
@@ -977,7 +984,8 @@ class TestBlueskyClient:
         mock_post_record.text = "Test post with labels"
         mock_post_record.created_at = "2025-01-01T10:00:00.000Z"
         mock_post_record.facets = []
-        mock_post_record.embed = None
+        if hasattr(mock_post_record, "embed"):
+            delattr(mock_post_record, "embed")
         mock_post_record.reply = None
         mock_post_record.labels = mock_labels
         mock_post_record.langs = None
@@ -1024,7 +1032,8 @@ class TestBlueskyClient:
         mock_post_record.text = "Test post with single label"
         mock_post_record.created_at = "2025-01-01T10:00:00.000Z"
         mock_post_record.facets = []
-        mock_post_record.embed = None
+        if hasattr(mock_post_record, "embed"):
+            delattr(mock_post_record, "embed")
         mock_post_record.reply = None
         mock_post_record.labels = mock_labels
         mock_post_record.langs = None
@@ -1068,7 +1077,8 @@ class TestBlueskyClient:
         mock_post_record.text = "Test post without labels"
         mock_post_record.created_at = "2025-01-01T10:00:00.000Z"
         mock_post_record.facets = []
-        mock_post_record.embed = None
+        if hasattr(mock_post_record, "embed"):
+            delattr(mock_post_record, "embed")
         mock_post_record.reply = None
         # Explicitly set labels to None to indicate no labels
         mock_post_record.labels = None
@@ -1113,7 +1123,8 @@ class TestBlueskyClient:
         mock_post_record.text = "Test post in English"
         mock_post_record.created_at = "2025-01-01T10:00:00.000Z"
         mock_post_record.facets = []
-        mock_post_record.embed = None
+        if hasattr(mock_post_record, "embed"):
+            delattr(mock_post_record, "embed")
         mock_post_record.reply = None
         mock_post_record.labels = None
         mock_post_record.langs = ["en"]
@@ -1157,7 +1168,8 @@ class TestBlueskyClient:
         mock_post_record.text = "Bilingual post / Post bilingüe"
         mock_post_record.created_at = "2025-01-01T10:00:00.000Z"
         mock_post_record.facets = []
-        mock_post_record.embed = None
+        if hasattr(mock_post_record, "embed"):
+            delattr(mock_post_record, "embed")
         mock_post_record.reply = None
         mock_post_record.labels = None
         mock_post_record.langs = ["en", "es"]
@@ -1201,7 +1213,8 @@ class TestBlueskyClient:
         mock_post_record.text = "Post without language metadata"
         mock_post_record.created_at = "2025-01-01T10:00:00.000Z"
         mock_post_record.facets = []
-        mock_post_record.embed = None
+        if hasattr(mock_post_record, "embed"):
+            delattr(mock_post_record, "embed")
         mock_post_record.reply = None
         mock_post_record.labels = None
         mock_post_record.langs = None
@@ -1248,6 +1261,8 @@ class TestBlueskyClient:
         mock_post_record.facets = []
         mock_post_record.labels = None
         mock_post_record.langs = None
+        if hasattr(mock_post_record, "embed"):
+            delattr(mock_post_record, "embed")
 
         # Add quote post embed (quoting someone else's post)
         mock_embed = Mock()
@@ -1255,7 +1270,6 @@ class TestBlueskyClient:
         mock_embed_record = Mock()
         mock_embed_record.uri = "at://did:plc:userB/app.bsky.feed.post/quoted123"
         mock_embed.record = mock_embed_record
-        mock_post_record.embed = mock_embed
 
         mock_feed_item = Mock()
         if hasattr(mock_feed_item, "reason"):
@@ -1265,6 +1279,7 @@ class TestBlueskyClient:
         mock_feed_item.post.uri = "at://did:plc:userA/app.bsky.feed.post/12345"
         mock_feed_item.post.cid = "test-cid"
         mock_feed_item.post.record = mock_post_record
+        mock_feed_item.post.embed = mock_embed
         mock_feed_item.post.author = Mock()
         mock_feed_item.post.author.handle = "userA.bsky.social"
         mock_feed_item.post.author.display_name = "User A"
@@ -1300,6 +1315,8 @@ class TestBlueskyClient:
         mock_post_record.facets = []
         mock_post_record.labels = None
         mock_post_record.langs = None
+        if hasattr(mock_post_record, "embed"):
+            delattr(mock_post_record, "embed")
 
         # Add quote post embed (quoting own post)
         mock_embed = Mock()
@@ -1307,7 +1324,6 @@ class TestBlueskyClient:
         mock_embed_record = Mock()
         mock_embed_record.uri = "at://did:plc:userA/app.bsky.feed.post/original123"
         mock_embed.record = mock_embed_record
-        mock_post_record.embed = mock_embed
 
         mock_feed_item = Mock()
         if hasattr(mock_feed_item, "reason"):
@@ -1317,6 +1333,7 @@ class TestBlueskyClient:
         mock_feed_item.post.uri = "at://did:plc:userA/app.bsky.feed.post/12345"
         mock_feed_item.post.cid = "test-cid"
         mock_feed_item.post.record = mock_post_record
+        mock_feed_item.post.embed = mock_embed
         mock_feed_item.post.author = Mock()
         mock_feed_item.post.author.handle = "userA.bsky.social"
         mock_feed_item.post.author.display_name = "User A"
@@ -1357,7 +1374,8 @@ class TestBlueskyClient:
         mock_post1.record.facets = []
         mock_post1.record.labels = None
         mock_post1.record.langs = None
-        mock_post1.record.embed = None
+        if hasattr(mock_post1, "embed"):
+            delattr(mock_post1, "embed")
         mock_post1.uri = "at://did:plc:userA/app.bsky.feed.post/post1"
         mock_post1.cid = "cid1"
         mock_post1.author = Mock()
@@ -1379,11 +1397,13 @@ class TestBlueskyClient:
         mock_post2.record.facets = []
         mock_post2.record.labels = None
         mock_post2.record.langs = None
+        if hasattr(mock_post2.record, "embed"):
+            delattr(mock_post2.record, "embed")
         mock_embed2 = Mock()
         mock_embed2.py_type = "app.bsky.embed.record"
         mock_embed2.record = Mock()
         mock_embed2.record.uri = "at://did:plc:userB/app.bsky.feed.post/quoted"
-        mock_post2.record.embed = mock_embed2
+        mock_post2.embed = mock_embed2
         mock_post2.uri = "at://did:plc:userA/app.bsky.feed.post/post2"
         mock_post2.cid = "cid2"
         mock_post2.author = Mock()
@@ -1405,11 +1425,13 @@ class TestBlueskyClient:
         mock_post3.record.facets = []
         mock_post3.record.labels = None
         mock_post3.record.langs = None
+        if hasattr(mock_post3.record, "embed"):
+            delattr(mock_post3.record, "embed")
         mock_embed3 = Mock()
         mock_embed3.py_type = "app.bsky.embed.record"
         mock_embed3.record = Mock()
         mock_embed3.record.uri = "at://did:plc:userA/app.bsky.feed.post/original"
-        mock_post3.record.embed = mock_embed3
+        mock_post3.embed = mock_embed3
         mock_post3.uri = "at://did:plc:userA/app.bsky.feed.post/post3"
         mock_post3.cid = "cid3"
         mock_post3.author = Mock()

--- a/tests/test_bluesky_client_additional.py
+++ b/tests/test_bluesky_client_additional.py
@@ -439,3 +439,333 @@ class TestBlueskyDataClasses:
 
         # Mutation of one instance must not affect the other
         assert "at://user/post/1" not in result_b.filtered_posts
+
+    def test_dataclass_initialization_no_filtered_posts(self):
+        """Test initialization when filtered_posts is None"""
+        result = BlueskyFetchResult(
+            posts=[],
+            total_retrieved=0,
+            filtered_replies=0,
+            filtered_reposts=0,
+            filtered_by_date=0,
+            filtered_quotes=0,
+            filtered_posts=None
+        )
+        assert result.filtered_posts == {}
+
+class TestBlueskyClientAdditional:
+    """Additional tests for BlueskyClient"""
+
+    def test_extract_did_from_uri_empty_identifier(self):
+        """Test extracting DID from URI with empty identifier"""
+        client = BlueskyClient("test.bsky.social", "test-password")
+        assert client._extract_did_from_uri("at://did:plc:/app.bsky.feed.post/12345") is None
+
+    def test_get_recent_posts_malformed_uri_in_reply(self):
+        """Test handling malformed URIs in reply"""
+        mock_client = Mock()
+        mock_me = Mock()
+        mock_me.did = "did:plc:test123"
+        mock_client.me = mock_me
+
+        mock_reply = Mock()
+        mock_reply.root = Mock()
+        mock_reply.root.uri = "malformed:uri"
+        mock_reply.parent = Mock()
+        mock_reply.parent.uri = "another:malformed:uri"
+
+        mock_post_record = Mock()
+        mock_post_record.text = "This is a reply"
+        mock_post_record.created_at = "2025-01-01T10:00:00.000Z"
+        mock_post_record.facets = []
+        mock_post_record.reply = mock_reply
+        mock_post_record.labels = None
+        mock_post_record.langs = None
+        if hasattr(mock_post_record, "embed"):
+            delattr(mock_post_record, "embed")
+
+        mock_feed_item = Mock()
+        if hasattr(mock_feed_item, "reason"):
+            delattr(mock_feed_item, "reason")
+
+        mock_feed_item.post = Mock()
+        mock_feed_item.post.uri = "at://did:plc:test123/app.bsky.feed.post/12345"
+        mock_feed_item.post.cid = "test-cid"
+        mock_feed_item.post.record = mock_post_record
+        mock_feed_item.post.author = Mock()
+        mock_feed_item.post.author.handle = "test.bsky.social"
+        mock_feed_item.post.author.display_name = "Test User"
+        if hasattr(mock_feed_item.post, "embed"):
+            delattr(mock_feed_item.post, "embed")
+
+        mock_response = Mock()
+        mock_response.feed = [mock_feed_item]
+        mock_client.get_author_feed.return_value = mock_response
+
+        client = BlueskyClient("test.bsky.social", "test-password")
+        client.client = mock_client
+        client._authenticated = True
+
+        result = client.get_recent_posts()
+        assert result.filtered_replies == 1
+        assert result.filtered_posts["at://did:plc:test123/app.bsky.feed.post/12345"] == "reply-not-self-threaded"
+
+    def test_extract_facets_data_exception(self):
+        """Test extract_facets_data exception handling"""
+        mock_facet = Mock()
+        # Mock index but make it raise exception when accessed
+        type(mock_facet).index = property(lambda self: (_ for _ in ()).throw(Exception("Test error")))
+
+        result = BlueskyClient._extract_facets_data([mock_facet])
+        assert result == []
+
+    def test_extract_embed_data_image_ref_dict(self):
+        """Test extract embed data with dict image ref"""
+        mock_embed = Mock()
+        mock_embed.py_type = "app.bsky.embed.images"
+
+        mock_image = Mock()
+        mock_image.alt = "Test alt"
+        mock_image_blob = Mock()
+        mock_image_blob.mime_type = "image/jpeg"
+        mock_image_blob.size = 1234
+        # Use simple dict for ref to test fallback branch
+        mock_image_blob.ref = {"somedata": "value"}
+        if hasattr(mock_image_blob.ref, "link"):
+            delattr(mock_image_blob.ref, "link")
+        if hasattr(mock_image_blob.ref, "$link"):
+            delattr(mock_image_blob.ref, "$link")
+
+        mock_image.image = mock_image_blob
+        mock_embed.images = [mock_image]
+        if hasattr(mock_embed, "external"):
+            delattr(mock_embed, "external")
+        if hasattr(mock_embed, "media"):
+            delattr(mock_embed, "media")
+        if hasattr(mock_embed, "video"):
+            delattr(mock_embed, "video")
+        if hasattr(mock_embed, "record"):
+            delattr(mock_embed, "record")
+
+        result = BlueskyClient._extract_embed_data(mock_embed)
+        assert result is not None
+        assert result["images"][0]["image"]["ref"] == {"somedata": "value"}
+
+    def test_extract_embed_data_video_ref_fallback(self):
+        """Test extract embed data video ref fallback to str"""
+        mock_embed = Mock()
+        mock_embed.py_type = "app.bsky.embed.video"
+
+        mock_video = Mock()
+        mock_video_blob = Mock()
+        mock_video_blob.mime_type = "video/mp4"
+        mock_video_blob.size = 1234
+        class MockRefFallback:
+            def __str__(self):
+                return "justastring"
+        mock_video_blob.ref = MockRefFallback()
+
+        mock_video.ref = MockRefFallback()
+        mock_video.mime_type = "video/mp4"
+        mock_video.size = 1234
+        if hasattr(mock_video, "video"):
+            delattr(mock_video, "video")
+        mock_embed.video = mock_video
+        if hasattr(mock_embed, "external"):
+            delattr(mock_embed, "external")
+        if hasattr(mock_embed, "images"):
+            delattr(mock_embed, "images")
+        if hasattr(mock_embed, "media"):
+            delattr(mock_embed, "media")
+        if hasattr(mock_embed, "record"):
+            delattr(mock_embed, "record")
+
+        result = BlueskyClient._extract_embed_data(mock_embed)
+        assert result is not None
+        assert result["video"]["blob_ref"] == "justastring"
+
+    @patch("src.bluesky_client.requests.get")
+    def test_download_blob_fallback_mime_type(self, mock_get):
+        """Test download blob fallback to image/jpeg mime type"""
+        mock_response = Mock()
+        mock_response.content = b"fakeimage"
+        # Return a content type that doesn't start with image/
+        mock_response.headers = {"content-type": "application/octet-stream"}
+        mock_get.return_value = mock_response
+
+        client = BlueskyClient("test.bsky.social", "test-password")
+        client.client = Mock() # mock client so hasattr doesn't fail
+        client.client.access_token = "fake_token"
+        client._authenticated = True
+
+        result = client.download_blob("fake_blob", "did:plc:123")
+        assert result is not None
+        assert result[1] == "image/jpeg"
+
+    def test_download_video_unauthenticated(self):
+        """Test download video unauthenticated returns None instead of raising ValueError (it logs an error)"""
+        client = BlueskyClient("test.bsky.social", "test-password")
+        # client is not authenticated
+        result = client.download_video("fake_blob", "did:plc:123")
+        assert result is None
+
+    @patch("src.bluesky_client.requests.get")
+    def test_download_video_exception(self, mock_get):
+        """Test download video handling exceptions"""
+        mock_get.side_effect = Exception("Test exception")
+
+        client = BlueskyClient("test.bsky.social", "test-password")
+        client.client = Mock()
+        client.client.access_token = "fake_token"
+        client._authenticated = True
+
+        result = client.download_video("fake_blob", "did:plc:123")
+        assert result is None
+
+    def test_download_blob_unauthenticated(self):
+        """Test download blob unauthenticated returns None"""
+        client = BlueskyClient("test.bsky.social", "test-password")
+        # client is not authenticated
+        result = client.download_blob("fake_blob", "did:plc:123")
+        assert result is None
+
+    @patch("src.bluesky_client.requests.get")
+    def test_download_video_success(self, mock_get):
+        """Test download video successful"""
+        mock_response = Mock()
+        mock_response.content = b"fakevideo"
+        mock_response.headers = {"content-type": "video/webm"}
+        mock_get.return_value = mock_response
+
+        client = BlueskyClient("test.bsky.social", "test-password")
+        client.client = Mock()
+        client.client.access_token = "fake_token"
+        client._authenticated = True
+
+        result = client.download_video("fake_blob", "did:plc:123")
+        assert result is not None
+        assert result[0] == b"fakevideo"
+        assert result[1] == "video/webm"
+
+    @patch("src.bluesky_client.requests.get")
+    def test_download_video_success_no_token(self, mock_get):
+        """Test download video successful without token"""
+        mock_response = Mock()
+        mock_response.content = b"fakevideo"
+        mock_response.headers = {"content-type": "video/webm"}
+        mock_get.return_value = mock_response
+
+        client = BlueskyClient("test.bsky.social", "test-password")
+        client.client = Mock()
+        client.client.access_token = None
+        client._authenticated = True
+
+        result = client.download_video("fake_blob", "did:plc:123")
+        assert result is not None
+
+    def test_extract_did_from_uri_exception(self):
+        """Test extract did from uri handling index error internally without crashing if split behaves unexpectedly"""
+        client = BlueskyClient("test.bsky.social", "test-password")
+        # Providing something that triggers an AttributeError when split() is called
+        result = client._extract_did_from_uri(None)
+        assert result is None
+
+
+    def test_extract_did_from_uri_invalid_start(self):
+        """Test extract did from uri not starting with did:"""
+        client = BlueskyClient("test.bsky.social", "test-password")
+        assert client._extract_did_from_uri("at://notadid:12345/app.bsky.feed.post/123") is None
+
+    def test_extract_did_from_uri_less_than_3_parts(self):
+        """Test extract did from uri with less than 3 parts"""
+        client = BlueskyClient("test.bsky.social", "test-password")
+        assert client._extract_did_from_uri("at://did:plc/app.bsky.feed.post/123") is None
+
+
+    def test_extract_embed_data_image_ref_dict_fallback(self):
+        """Test extract embed data with dict image ref that uses $link internally (not hasattr)"""
+        mock_embed = Mock()
+        mock_embed.py_type = "app.bsky.embed.images"
+
+        mock_image = Mock()
+        mock_image.alt = "Test alt"
+        mock_image_blob = Mock()
+        mock_image_blob.mime_type = "image/jpeg"
+        mock_image_blob.size = 1234
+
+        # We need a dict-like mock for the ref
+        # so hasattr(ref, "$link") fails, but we want it to act like a dict with "$link"
+        # Wait, the code says: `elif hasattr(ref, "$link"):`
+        # if `hasattr` is true, it goes to `ref["$link"]`
+        class MockRefDollarLink:
+            def __getitem__(self, key):
+                return "some_link_value"
+        ref = MockRefDollarLink()
+        setattr(ref, "$link", True) # Make hasattr return True
+        if hasattr(ref, "link"):
+            delattr(ref, "link")
+        mock_image_blob.ref = ref
+
+        mock_image.image = mock_image_blob
+        mock_embed.images = [mock_image]
+        if hasattr(mock_embed, "external"):
+            delattr(mock_embed, "external")
+        if hasattr(mock_embed, "media"):
+            delattr(mock_embed, "media")
+        if hasattr(mock_embed, "video"):
+            delattr(mock_embed, "video")
+        if hasattr(mock_embed, "record"):
+            delattr(mock_embed, "record")
+
+        result = BlueskyClient._extract_embed_data(mock_embed)
+        assert result is not None
+        assert result["images"][0]["image"]["ref"]["$link"] == "some_link_value"
+
+
+    def test_extract_embed_data_video_ref_dict_fallback(self):
+        """Test extract embed data video ref fallback to dict with $link"""
+        mock_embed = Mock()
+        mock_embed.py_type = "app.bsky.embed.video"
+
+        mock_video = Mock()
+        mock_video.mime_type = "video/mp4"
+        mock_video.size = 1234
+
+        mock_video.ref = {"$link": "dict_link_val"}
+
+        if hasattr(mock_video, "video"):
+            delattr(mock_video, "video")
+        mock_embed.video = mock_video
+        if hasattr(mock_embed, "external"):
+            delattr(mock_embed, "external")
+        if hasattr(mock_embed, "images"):
+            delattr(mock_embed, "images")
+        if hasattr(mock_embed, "media"):
+            delattr(mock_embed, "media")
+        if hasattr(mock_embed, "record"):
+            delattr(mock_embed, "record")
+
+        result = BlueskyClient._extract_embed_data(mock_embed)
+        assert result is not None
+        assert result["video"]["blob_ref"] == "dict_link_val"
+
+
+
+    def test_extract_did_from_uri_index_error(self):
+        """Test extract did from uri handling IndexError internally"""
+        client = BlueskyClient("test.bsky.social", "test-password")
+        # Pass a custom mock string that raises IndexError on split
+        class MockString(str):
+            def split(self, *args, **kwargs):
+                raise IndexError("test index error")
+            def startswith(self, prefix):
+                return True
+
+        assert client._extract_did_from_uri(MockString("did:something")) is None
+
+
+    def test_extract_did_from_uri_attribute_error(self):
+        """Test extract did from uri handling AttributeError internally"""
+        client = BlueskyClient("test.bsky.social", "test-password")
+        # Trigger an attribute error by passing an object that lacks `startswith` or `split`
+        assert client._extract_did_from_uri(123) is None

--- a/tests/test_bluesky_client_additional.py
+++ b/tests/test_bluesky_client_additional.py
@@ -449,9 +449,10 @@ class TestBlueskyDataClasses:
             filtered_reposts=0,
             filtered_by_date=0,
             filtered_quotes=0,
-            filtered_posts=None
+            filtered_posts=None,
         )
         assert result.filtered_posts == {}
+
 
 class TestBlueskyClientAdditional:
     """Additional tests for BlueskyClient"""
@@ -459,7 +460,10 @@ class TestBlueskyClientAdditional:
     def test_extract_did_from_uri_empty_identifier(self):
         """Test extracting DID from URI with empty identifier"""
         client = BlueskyClient("test.bsky.social", "test-password")
-        assert client._extract_did_from_uri("at://did:plc:/app.bsky.feed.post/12345") is None
+        assert (
+            client._extract_did_from_uri("at://did:plc:/app.bsky.feed.post/12345")
+            is None
+        )
 
     def test_get_recent_posts_malformed_uri_in_reply(self):
         """Test handling malformed URIs in reply"""
@@ -508,13 +512,18 @@ class TestBlueskyClientAdditional:
 
         result = client.get_recent_posts()
         assert result.filtered_replies == 1
-        assert result.filtered_posts["at://did:plc:test123/app.bsky.feed.post/12345"] == "reply-not-self-threaded"
+        assert (
+            result.filtered_posts["at://did:plc:test123/app.bsky.feed.post/12345"]
+            == "reply-not-self-threaded"
+        )
 
     def test_extract_facets_data_exception(self):
         """Test extract_facets_data exception handling"""
         mock_facet = Mock()
         # Mock index but make it raise exception when accessed
-        type(mock_facet).index = property(lambda self: (_ for _ in ()).throw(Exception("Test error")))
+        type(mock_facet).index = property(
+            lambda self: (_ for _ in ()).throw(Exception("Test error"))
+        )
 
         result = BlueskyClient._extract_facets_data([mock_facet])
         assert result == []
@@ -560,9 +569,11 @@ class TestBlueskyClientAdditional:
         mock_video_blob = Mock()
         mock_video_blob.mime_type = "video/mp4"
         mock_video_blob.size = 1234
+
         class MockRefFallback:
             def __str__(self):
                 return "justastring"
+
         mock_video_blob.ref = MockRefFallback()
 
         mock_video.ref = MockRefFallback()
@@ -594,7 +605,7 @@ class TestBlueskyClientAdditional:
         mock_get.return_value = mock_response
 
         client = BlueskyClient("test.bsky.social", "test-password")
-        client.client = Mock() # mock client so hasattr doesn't fail
+        client.client = Mock()  # mock client so hasattr doesn't fail
         client.client.access_token = "fake_token"
         client._authenticated = True
 
@@ -670,17 +681,20 @@ class TestBlueskyClientAdditional:
         result = client._extract_did_from_uri(None)
         assert result is None
 
-
     def test_extract_did_from_uri_invalid_start(self):
         """Test extract did from uri not starting with did:"""
         client = BlueskyClient("test.bsky.social", "test-password")
-        assert client._extract_did_from_uri("at://notadid:12345/app.bsky.feed.post/123") is None
+        assert (
+            client._extract_did_from_uri("at://notadid:12345/app.bsky.feed.post/123")
+            is None
+        )
 
     def test_extract_did_from_uri_less_than_3_parts(self):
         """Test extract did from uri with less than 3 parts"""
         client = BlueskyClient("test.bsky.social", "test-password")
-        assert client._extract_did_from_uri("at://did:plc/app.bsky.feed.post/123") is None
-
+        assert (
+            client._extract_did_from_uri("at://did:plc/app.bsky.feed.post/123") is None
+        )
 
     def test_extract_embed_data_image_ref_dict_fallback(self):
         """Test extract embed data with dict image ref that uses $link internally (not hasattr)"""
@@ -700,8 +714,9 @@ class TestBlueskyClientAdditional:
         class MockRefDollarLink:
             def __getitem__(self, key):
                 return "some_link_value"
+
         ref = MockRefDollarLink()
-        setattr(ref, "$link", True) # Make hasattr return True
+        setattr(ref, "$link", True)  # Make hasattr return True
         if hasattr(ref, "link"):
             delattr(ref, "link")
         mock_image_blob.ref = ref
@@ -720,7 +735,6 @@ class TestBlueskyClientAdditional:
         result = BlueskyClient._extract_embed_data(mock_embed)
         assert result is not None
         assert result["images"][0]["image"]["ref"]["$link"] == "some_link_value"
-
 
     def test_extract_embed_data_video_ref_dict_fallback(self):
         """Test extract embed data video ref fallback to dict with $link"""
@@ -749,20 +763,19 @@ class TestBlueskyClientAdditional:
         assert result is not None
         assert result["video"]["blob_ref"] == "dict_link_val"
 
-
-
     def test_extract_did_from_uri_index_error(self):
         """Test extract did from uri handling IndexError internally"""
         client = BlueskyClient("test.bsky.social", "test-password")
+
         # Pass a custom mock string that raises IndexError on split
         class MockString(str):
             def split(self, *args, **kwargs):
                 raise IndexError("test index error")
+
             def startswith(self, prefix):
                 return True
 
         assert client._extract_did_from_uri(MockString("did:something")) is None
-
 
     def test_extract_did_from_uri_attribute_error(self):
         """Test extract did from uri handling AttributeError internally"""


### PR DESCRIPTION
Resolves an issue where `BlueskyClient` was missing data by relying on raw record embeds rather than the hydrated API response. Additionally refactors unit tests to account for AT Protocol objects more effectively and bolsters `BlueskyClient` coverage near 100%. Ensures all tests run safely in Python 3.12 via `run_tests.py`.

---
*PR created automatically by Jules for task [11401459400950851079](https://jules.google.com/task/11401459400950851079) started by @hossain-khan*